### PR TITLE
Update storage_set_rpo_default.rb

### DIFF
--- a/google-cloud-storage/samples/storage_set_rpo_default.rb
+++ b/google-cloud-storage/samples/storage_set_rpo_default.rb
@@ -24,7 +24,7 @@ def set_rpo_default bucket_name:
 
   bucket.rpo = :DEFAULT
 
-  puts "Turbo replication is set to default for #{bucket_name}."
+  puts "The replication behavior or recovery point objective (RPO) for #{bucket_name} is set to default."
 end
 # [END storage_set_rpo_default]
 


### PR DESCRIPTION
@ddelgrosso We'll need to update the printed output on line 27. Turbo replication is not set to default, the replication behavior or recovery point objective (rpo) on the bucket is set to default. See proposed changes. Thanks!

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
- [ ] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
- [ ] Update code documentation if necessary.

closes: #<issue_number_goes_here>