### PR TITLE
Update storage_create_bucket_turbo_replication.rb

### DIFF
--- a/google-cloud-storage/samples/storage_create_bucket_turbo_replication.rb
+++ b/google-cloud-storage/samples/storage_create_bucket_turbo_replication.rb
@@ -24,7 +24,7 @@ def create_bucket_turbo_replication bucket_name:
                                   location: "ASIA",
                                   rpo:      "ASYNC_TURBO"
 
-  puts "Created bucket #{bucket.name} in #{bucket.location} with turbo replication set to #{bucket.rpo}."
+  puts "Created bucket #{bucket.name} in #{bucket.location} with the recovery point objective (RPO) set to #{bucket.rpo}."
 end
 # [END storage_create_bucket_turbo_replication]
 


### PR DESCRIPTION
@ddelgrosso 
In this sample, the recovery point objective or (RPO) is set, not turbo replication. Related to b/217259317.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
- [ ] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
- [ ] Update code documentation if necessary.

closes: #<issue_number_goes_here>